### PR TITLE
Add support for text-2.0 (fixes #2)

### DIFF
--- a/monad-logger-aeson/CHANGELOG.md
+++ b/monad-logger-aeson/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## Unreleased version
+
+* Support `text-2.0`
+
 ## 0.2.0.1
 
 * Relax dependency lower bounds to support GHC 8.8 (@pbrisbin)

--- a/monad-logger-aeson/monad-logger-aeson.cabal
+++ b/monad-logger-aeson/monad-logger-aeson.cabal
@@ -48,7 +48,7 @@ library
     , exceptions >=0.10.4 && <0.11.0
     , fast-logger >=3.0.2 && <3.2.0
     , monad-logger >=0.3.36 && <0.4.0
-    , text >=1.2.4.0 && <1.3.0.0
+    , text >=1.2.4.0 && <1.3.0.0 || >=2.0 && <2.1
     , time >=1.9.3 && <1.12.0.0
     , unordered-containers >=0.2.10.0 && <0.3.0.0
   default-language: Haskell2010
@@ -65,7 +65,7 @@ executable readme-example
     , base >=4.13.0.0 && <5
     , monad-logger >=0.3.36 && <0.4.0
     , monad-logger-aeson
-    , text >=1.2.4.0 && <1.3.0.0
+    , text >=1.2.4.0 && <1.3.0.0 || >=2.0 && <2.1
   default-language: Haskell2010
 
 test-suite monad-logger-aeson-test-suite

--- a/monad-logger-aeson/package.yaml
+++ b/monad-logger-aeson/package.yaml
@@ -36,7 +36,7 @@ library:
   - exceptions >=0.10.4 && <0.11.0
   - fast-logger >=3.0.2 && <3.2.0
   - monad-logger >=0.3.36 && <0.4.0
-  - text >=1.2.4.0 && <1.3.0.0
+  - text >=1.2.4.0 && <1.3.0.0 || >=2.0 && <2.1
   - time >=1.9.3 && <1.12.0.0
   - unordered-containers >=0.2.10.0 && <0.3.0.0
   source-dirs: library
@@ -67,4 +67,4 @@ executables:
     - base >=4.13.0.0 && <5
     - monad-logger >=0.3.36 && <0.4.0
     - monad-logger-aeson
-    - text >=1.2.4.0 && <1.3.0.0
+    - text >=1.2.4.0 && <1.3.0.0 || >=2.0 && <2.1


### PR DESCRIPTION
This PR adds support for `text-2.0` (see #2).

There isn't a super clean way to test this in the project's CI just yet, outside of adding a custom `stack.yaml` tailored specifically for `text-2.0`. I have tested the project with `text-2.0` locally though, and when a Stackage nightly starts picking up `text-2.0`, we can get it tested in CI very easily.