### PR TITLE
Enable CI on PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: main
 
 jobs:
   build:


### PR DESCRIPTION
CI was only officially running on the `main` branch previously. This PR enables CI running on pulls as well.