### PR TITLE
Add SeriesElem for safety when constructing message metadata

### DIFF
--- a/monad-logger-aeson/CHANGELOG.md
+++ b/monad-logger-aeson/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## Unreleased version
+
+* Message metadata is now of type `[SeriesElem]` instead of `[Series]`
+  * _Should_ be backwards-compatible based on library's recommended usage
+
 ## 0.2.0.2
 
 * Support `text-2.0`

--- a/monad-logger-aeson/library/Control/Monad/Logger/Aeson.hs
+++ b/monad-logger-aeson/library/Control/Monad/Logger/Aeson.hs
@@ -9,6 +9,7 @@ module Control.Monad.Logger.Aeson
 
     -- * Types
     Message(..)
+  , SeriesElem
   , (.@)
   , LoggedMessage(..)
 
@@ -91,7 +92,7 @@ import Control.Monad.Logger as Log hiding
 import Control.Monad.Catch (MonadMask, MonadThrow)
 import Control.Monad.IO.Class (MonadIO(liftIO))
 import Control.Monad.Logger.Aeson.Internal
-  ( LoggedMessage(..), Message(..), OutputOptions(..), (.@), KeyMap
+  ( LoggedMessage(..), Message(..), OutputOptions(..), (.@), KeyMap, SeriesElem
   )
 import Data.Aeson (KeyValue((.=)), Value(String))
 import Data.Aeson.Types (Pair)


### PR DESCRIPTION
Prior to this PR, the `Message` type was defined as:

```haskell
data Message = Text :# [Series]
```

Now it is defined as:

```haskell
data Message = Text :# [SeriesElem]
```

`SeriesElem` is a more restricted form of `Series` that has no `Monoid` or `Semigroup` instances:
* Not having `Monoid` enforces that the user can't accidentally use `mempty` and then wind up with the meaningless `"meta": {}` in their logs.
* Not having `Semigroup` is less about safety and more about matching intuition: the metadata itself is a list, so each element of the list should be a key-value pair, but with `Semigroup`, each element of the list could be some "sub-list" of key-value pairs, e.g.:
  ```haskell
  logDebug $ "Doing stuff" :# [("x" .= (42 :: Int) <> "y" .= (43 :: Int))]
  ```