### PR TITLE
Remove deprecated (.@) operator

### DIFF
--- a/monad-logger-aeson/CHANGELOG.md
+++ b/monad-logger-aeson/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased version
 
+* Remove deprecated `(.@)` operator
 * Message metadata is now of type `[SeriesElem]` instead of `[Series]`
   * _Should_ be backwards-compatible based on library's recommended usage
 

--- a/monad-logger-aeson/library/Control/Monad/Logger/Aeson.hs
+++ b/monad-logger-aeson/library/Control/Monad/Logger/Aeson.hs
@@ -10,7 +10,6 @@ module Control.Monad.Logger.Aeson
     -- * Types
     Message(..)
   , SeriesElem
-  , (.@)
   , LoggedMessage(..)
 
     -- * Logging functions
@@ -92,7 +91,7 @@ import Control.Monad.Logger as Log hiding
 import Control.Monad.Catch (MonadMask, MonadThrow)
 import Control.Monad.IO.Class (MonadIO(liftIO))
 import Control.Monad.Logger.Aeson.Internal
-  ( LoggedMessage(..), Message(..), OutputOptions(..), (.@), KeyMap, SeriesElem
+  ( LoggedMessage(..), Message(..), OutputOptions(..), KeyMap, SeriesElem
   )
 import Data.Aeson (KeyValue((.=)), Value(String))
 import Data.Aeson.Types (Pair)

--- a/monad-logger-aeson/library/Control/Monad/Logger/Aeson/Internal.hs
+++ b/monad-logger-aeson/library/Control/Monad/Logger/Aeson/Internal.hs
@@ -14,7 +14,6 @@ module Control.Monad.Logger.Aeson.Internal
     -- ** @Message@-related
     Message(..)
   , SeriesElem(..)
-  , (.@)
   , LoggedMessage(..)
   , threadContextStore
   , logCS
@@ -110,16 +109,6 @@ keyMapUnion = AesonCompat.union
 newtype SeriesElem = UnsafeSeriesElem
   { unSeriesElem :: Series
   } deriving (KeyValue) via Series
-
--- | Synonym for '(.=)' from @aeson@.
---
--- This operator is deprecated and will be removed in a future version. Please
--- use '(.=)' instead, which is re-exported from "Data.Aeson".
---
--- @since 0.1.0.0
-(.@) :: (KeyValue kv, ToJSON v) => Key -> v -> kv
-(.@) = (.=)
-{-# DEPRECATED (.@) "This operator will be removed in a future major version." #-}
 
 -- | This type is the Haskell representation of each JSON log message produced
 -- by this library.


### PR DESCRIPTION
`monad-logger-aeson-0.2.0.0` deprecated `(.@)` and started re-exporting `aeson`'s `(.=)` instead. The next release is planned to be a major version bump, so now's a good time to go ahead and whack the deprecated `(.@)` operator.