### PR TITLE
Add Semigroup instance for SeriesElem

### DIFF
--- a/monad-logger-aeson/CHANGELOG.md
+++ b/monad-logger-aeson/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## Unreleased version
+
+* Add `Semigroup` instance for `SeriesElem`
+
 ## 0.3.0.2
 
 * Backwards compatibility down to GHC 8.4 (@pbrisbin)

--- a/monad-logger-aeson/library/Control/Monad/Logger/Aeson/Internal.hs
+++ b/monad-logger-aeson/library/Control/Monad/Logger/Aeson/Internal.hs
@@ -107,15 +107,21 @@ keyMapUnion :: KeyMap v -> KeyMap v -> KeyMap v
 keyMapUnion = AesonCompat.union
 
 -- | A single key-value pair, where the value is encoded JSON. This is a more
--- restricted version of 'Series': a 'SeriesElem' encapsulates exactly one
--- key-value pair, whereas a 'Series' encapsulates zero or more key-value pairs.
+-- restricted version of 'Series': a 'SeriesElem' is intended to encapsulate
+-- exactly one key-value pair, whereas a 'Series' encapsulates zero or more
+-- key-value pairs. 'SeriesElem' values can be created via '(.=)' from @aeson@.
 --
--- Values of this type are only created via '(.=)' from @aeson@.
+-- While a 'SeriesElem' most often will map to a single pair, note that a
+-- 'Semigroup' instance is available for performance's sake. The 'Semigroup'
+-- instance is useful when multiple pairs are grouped together and then shared
+-- across multiple logging calls. In that case, the cost of combining the pairs
+-- in the group must only be paid once.
 --
 -- @since 0.3.0.0
 newtype SeriesElem = UnsafeSeriesElem
   { unSeriesElem :: Series
-  } deriving newtype KeyValue
+  } deriving newtype (KeyValue) -- ^ @since 0.3.0.0
+    deriving newtype (Semigroup) -- ^ @since 0.3.1.0
 
 -- | This type is the Haskell representation of each JSON log message produced
 -- by this library.

--- a/monad-logger-aeson/library/Control/Monad/Logger/Aeson/Internal.hs
+++ b/monad-logger-aeson/library/Control/Monad/Logger/Aeson/Internal.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE StrictData #-}
 module Control.Monad.Logger.Aeson.Internal
   ( -- * Disclaimer
@@ -120,8 +121,12 @@ keyMapUnion = AesonCompat.union
 -- @since 0.3.0.0
 newtype SeriesElem = UnsafeSeriesElem
   { unSeriesElem :: Series
-  } deriving newtype (KeyValue) -- ^ @since 0.3.0.0
-    deriving newtype (Semigroup) -- ^ @since 0.3.1.0
+  }
+
+-- | @since 0.3.0.0
+deriving newtype instance KeyValue SeriesElem
+-- | @since 0.3.1.0
+deriving newtype instance Semigroup SeriesElem
 
 -- | This type is the Haskell representation of each JSON log message produced
 -- by this library.


### PR DESCRIPTION
This PR adds a `Semigroup` instance for `SeriesElem` for performance's sake. This allows for grouping together pairs that will be common across multiple logging calls, while only paying the cost of doing the grouping once:

```haskell
foo :: (MonadLogger m) => m ()
foo = do
  logDebug $ "Some log message with metadata" :# [common]
  logDebug $ "Another log message using same metadata" :# [common]
  where
  common :: SeriesElem
  common = "bloorp" .= (42 :: Int) <> "bonk" .= ("abc" :: Text)
```

This takes `SeriesElem` from encapsulating exactly one pair to instead encapsulate one or more pairs.