### PR TITLE
feat: Support GHC-9.8 ...

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,3 +29,35 @@ jobs:
       with:
         stack-yaml: stack/stack-${{ matrix.resolver }}.yaml
         stack-arguments: --bench --no-run-benchmarks --haddock --no-haddock-deps
+
+  build-9_8:
+    name: Haskell Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        ghc-version:
+          - '9.8'
+        cabal-version: ['3.10.2.0']
+    steps:
+      # Checkout
+      - uses: actions/checkout@v3
+        
+      # Setup
+      - name: Setup Haskell
+        uses: haskell-actions/setup@v2
+        id: setup
+        with:
+          ghc-version: ${{ matrix.ghc-version }}
+          cabal-version: ${{ matrix.cabal-version }}
+
+      - name: Cabal Bulid
+        run: |
+          (cat << EOF
+          tests: True
+          packages:
+            monad-logger-aeson
+          EOF
+          ) > cabal.project
+          cabal test all

--- a/monad-logger-aeson/monad-logger-aeson.cabal
+++ b/monad-logger-aeson/monad-logger-aeson.cabal
@@ -48,7 +48,7 @@ library
     , exceptions >=0.10.0 && <0.11.0
     , fast-logger >=2.4.11 && <3.3.0
     , monad-logger >=0.3.30 && <0.4.0
-    , text >=1.2.3.1 && <1.3.0.0 || >=2.0 && <2.1
+    , text >=1.2.3.1 && <1.3.0.0 || >=2.0 && <2.2
     , time >=1.8.0.2 && <1.14
     , unordered-containers >=0.2.10.0 && <0.3.0.0
   default-language: Haskell2010
@@ -65,7 +65,7 @@ executable readme-example
     , base >=4.11.1.0 && <5
     , monad-logger >=0.3.30 && <0.4.0
     , monad-logger-aeson
-    , text >=1.2.3.1 && <1.3.0.0 || >=2.0 && <2.1
+    , text >=1.2.3.1 && <1.3.0.0 || >=2.0 && <2.2
   default-language: Haskell2010
 
 test-suite monad-logger-aeson-test-suite


### PR DESCRIPTION
... by relaxing the upper bounds of `text`, and adding a CI job to test with 9.8.

The CI job uses `cabal` instead of `stack` because the stack nightly hasn't moved to 9.8 yet. The intent is that it can be removed when stack catches up.